### PR TITLE
add an option to manually set Selenium driver path if not set in PATH…

### DIFF
--- a/3tzb.js
+++ b/3tzb.js
@@ -141,7 +141,8 @@ program.option('--output <absolute_path>', '[required] output file path')
     .option('--headless', 'use chrome in headless mode')
     .option('--force', 'force override of existing data')
     .option('--title <title>', 'filter auditions by title')
-    .option('--top <number>', 'get top <number> episodes for each audition');
+    .option('--top <number>', 'get top <number> episodes for each audition')
+    .option('--driver-path <absolute_path>', 'define path to Selenium driver manually if not set in PATH environment variable');
 
 program.command('get-auditions')
     .description('get list of auditions, can be filtered with `--title` option. ' +
@@ -218,6 +219,9 @@ async function getChromeDriver(headless) {
 
     if (headless)
         options.addArguments('headless');
+
+    if( program.driverPath )
+        chromeDriver.setDefaultService(new chromeDriver.ServiceBuilder(program.driverPath).build());
 
     return await new Builder()
         .forBrowser('chrome')

--- a/README.md
+++ b/README.md
@@ -29,18 +29,19 @@ npm i -g
 Usage: 3tzb [options] [command]
 
 Options:
-  --output <absolute_path>  [required] output file path
-  --input <absolute_path>   input file path
-  --headless                use chrome in headless mode
-  --force                   force override of existing data
-  --title <title>           filter auditions by title
-  --top <number>            get top <number> episodes for each audition
-  -h, --help                output usage information
+  --output <absolute_path>       [required] output file path
+  --input <absolute_path>        input file path
+  --headless                     use chrome in headless mode
+  --force                        force override of existing data
+  --title <title>                filter auditions by title
+  --top <number>                 get top <number> episodes for each audition
+  --driver-path <absolute_path>  define path to Selenium driver manually if not set in PATH environment variable
+  -h, --help                     output usage information
 
 Commands:
-  get-auditions             get list of auditions, can be filtered with `--title` option. To add audition to existing file use `--input` option
-  get-episodes              get episodes for auditions in file
-  get-files                 get files for auditions in file
+  get-auditions                  get list of auditions, can be filtered with `--title` option. To add audition to existing file use `--input` option
+  get-episodes                   get episodes for auditions in file
+  get-files                      get files for auditions in file
 ```
 
 Przykładowe pobranie listy audycji:


### PR DESCRIPTION
Cześć,
próbowałem odpalić Twoją apkę u siebie na komputerze i zorientowałem się że nie działała mi ona bo nie miałem podpiętego drivera Selenium for Chrome w zmiennej środowiskowej PATH na swoim komputerze. Poświęciłem więc troszkę czasu na dodanie opcji żeby można było przy uruchomieniu zdefiniować ręcznie ścieżkę dostępu do drivera.
Jeżeli zaakceptujesz moją poprawkę, będzie to wyglądało tak że jeśli przy uruchomieniu apki dodasz argument --driver-path:
3tzb <inne argumenty> --driver-path <ścieżka do drivera Selenium>,
to aplikacja zaciągnie drivera ze ścieżki jaką podasz w wartości tego argumentu.
Jeśli argumentu --driver-path nie będzie przy wywołaniu, to wszystko powinno zostać jak dawniej, czyli zaciąganie ze zmiennej środowiskowej (u mnie wtedy leci wyjątek i nic nie ma ;) ).
Jakby coś, to ja się bawiłem na Windowsie. Nie powinno to robić wielkiej różnicy, ale daję znać na wszelki wypadek.
Oczywiście to Twój projekt, więc zdecyduj jak zechcesz.
Może dobrze będzie jak spróbujesz to przetestować u siebie żebym Ci czegoś nie pochrzanił. ;)
Pozdrawiam.